### PR TITLE
Make services compatible with python3.8

### DIFF
--- a/resource/_action.pyi.em
+++ b/resource/_action.pyi.em
@@ -66,14 +66,14 @@ assert_namespace_equals(action, action.feedback_message.structure)
 }@
 @#>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 class @(action.namespaced_type.name)(metaclass=Metaclass_@(action.namespaced_type.name)):
-    Goal: typing.TypeAlias[@(action.goal.structure.namespaced_type.name)] = @(action.goal.structure.namespaced_type.name)
-    Result: typing.TypeAlias[@(action.result.structure.namespaced_type.name)] = @(action.result.structure.namespaced_type.name)
-    Feedback: typing.TypeAlias[@(action.feedback.structure.namespaced_type.name)] = @(action.feedback.structure.namespaced_type.name)
+    Goal: TypeAlias[@(action.goal.structure.namespaced_type.name)] = @(action.goal.structure.namespaced_type.name)
+    Result: TypeAlias[@(action.result.structure.namespaced_type.name)] = @(action.result.structure.namespaced_type.name)
+    Feedback: TypeAlias[@(action.feedback.structure.namespaced_type.name)] = @(action.feedback.structure.namespaced_type.name)
 
     class Impl:
-        SendGoalService: typing.TypeAlias[@(action.send_goal_service.namespaced_type.name)] = @(action.send_goal_service.namespaced_type.name)
-        GetResultService: typing.TypeAlias[@(action.get_result_service.namespaced_type.name)] = @(action.get_result_service.namespaced_type.name)
-        FeedbackMessage: typing.TypeAlias[@(action.feedback_message.structure.namespaced_type.name)] = @(action.feedback_message.structure.namespaced_type.name)
+        SendGoalService: TypeAlias[@(action.send_goal_service.namespaced_type.name)] = @(action.send_goal_service.namespaced_type.name)
+        GetResultService: TypeAlias[@(action.get_result_service.namespaced_type.name)] = @(action.get_result_service.namespaced_type.name)
+        FeedbackMessage: TypeAlias[@(action.feedback_message.structure.namespaced_type.name)] = @(action.feedback_message.structure.namespaced_type.name)
 
         from action_msgs.srv._cancel_goal import CancelGoal as CancelGoalService
         from action_msgs.msg._goal_status_array import GoalStatusArray as GoalStatusMessage

--- a/resource/_imports.pyi.em
+++ b/resource/_imports.pyi.em
@@ -3,10 +3,21 @@
 third_party_imports = set()
 first_party_imports = set()
 generator(component, defined_classes, third_party_imports, first_party_imports)
+
+import sys
+python_minor_version = sys.version_info.minor
 }@
+
 import typing
+@[if python_minor_version < 10]@
+from typing_extensions import TypeAlias
+@[else]@
+from typing import TypeAlias
+@[end if]
+
 import array
 import numpy as np
+
 @[if len(third_party_imports) > 0]@
 
 @[for statement in sorted(third_party_imports)]@

--- a/resource/_imports.pyi.em
+++ b/resource/_imports.pyi.em
@@ -4,16 +4,14 @@ third_party_imports = set()
 first_party_imports = set()
 generator(component, defined_classes, third_party_imports, first_party_imports)
 
-import sys
-python_minor_version = sys.version_info.minor
 }@
 
+import sys
 import typing
-@[if python_minor_version < 10]@
-from typing_extensions import TypeAlias
-@[else]@
-from typing import TypeAlias
-@[end if]
+if sys.version_info < (3, 10):
+    from typing_extensions import TypeAlias
+else:
+    from typing import TypeAlias
 
 import array
 import numpy as np

--- a/resource/_srv.pyi.em
+++ b/resource/_srv.pyi.em
@@ -41,7 +41,7 @@ assert service.response_message.structure.namespaced_type.namespaces == service.
 }@
 @#>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 class @(service.namespaced_type.name)(metaclass=Metaclass_@(service.namespaced_type.name)):
-    Request: typing.TypeAlias[@(service.request_message.structure.namespaced_type.name)] = @(service.request_message.structure.namespaced_type.name)
-    Response: typing.TypeAlias[@(service.response_message.structure.namespaced_type.name)] = @(service.response_message.structure.namespaced_type.name)
+    Request: TypeAlias[@(service.request_message.structure.namespaced_type.name)] = @(service.request_message.structure.namespaced_type.name)
+    Response: TypeAlias[@(service.response_message.structure.namespaced_type.name)] = @(service.response_message.structure.namespaced_type.name)
 
     def __init__(self) -> None: ...


### PR DESCRIPTION
First of all, thank you for providing this package! Unfortunately, I've had a bit of difficulty using Foxy, so I was wondering if you would accept the following patch.

Currently, services use typing.TypeAlias. However, this was only introduced in Python 3.10. Until then, we should use the backported version that's available in typing_extensions. Since stub files can not contain any dynamic imports, this is done inside the template by importing TypeAlias from either module.

Also update Actions, since they also use nested types.

I created a simple service that takes a string, and these are the results. Before:
```
Revealed type is "Any"
```

After:
```
Revealed type is "def (*, str: builtins.str =, **kwargs: Any) -> test_pkg.srv._set_string.SetString_Request"
```