### PR TITLE
fix: codegen for empty interface

### DIFF
--- a/resource/_msg.pyi.em
+++ b/resource/_msg.pyi.em
@@ -67,7 +67,9 @@ class @(message.structure.namespaced_type.name)(metaclass=Metaclass_@(message.st
 
     def __init__(
         self,
+@[if len(members)]@
         *,
+@[end if]@
 @[for name, annotation, noqa_string in members]@
         @(name): @(annotation.getter) = ...,@(noqa_string)
 @[end for]@


### PR DESCRIPTION
For empty interface like `std_msgs/msg/empty`, the generated code has syntax error.

```python3
    def __init__(
        self,
        *,  # SyntaxError: named arguments must follow bare *
        **kwargs: typing.Any,
    ) -> None: ...
```