### PR TITLE
Fix type annotation of array types in constructor

### DIFF
--- a/resource/_msg.pyi.em
+++ b/resource/_msg.pyi.em
@@ -71,7 +71,7 @@ class @(message.structure.namespaced_type.name)(metaclass=Metaclass_@(message.st
         *,
 @[end if]@
 @[for name, annotation, noqa_string in members]@
-        @(name): @(annotation.getter) = ...,@(noqa_string)
+        @(name): @(annotation.setter) = ...,@(noqa_string)
 @[end for]@
         **kwargs: typing.Any,
     ) -> None: ...


### PR DESCRIPTION
The type annotation of keyword arguments in the constructor of a message used the `getter` property. While this is fine for simple types, for array types it breaks down as:
- `getter` always returns an array
- `setter` takes any sequence as input So we should be using the setter type.

How to reproduce:
1. Create a message containing an array type such as the following `Vector.msg`: ``` float64[] data ```
2. Type-check the following snippet: ```python from my_pkg.msg import Vector vec = Vector(data=[1, 2, 3]) ```

Without this commit:
```
Argument "data" to "Vector" has incompatible type "List[float]"; expected "array[float]"  [arg-type]
```

With this commit: no errors