### PR TITLE
Fix the annotation for non trivial sequence

### DIFF
--- a/rosidl_generator_mypy/__init__.py
+++ b/rosidl_generator_mypy/__init__.py
@@ -165,7 +165,7 @@ def to_type_annotation(
 
         # eg: std_msgs/Header[]
         return Annotation(
-            "typing.Sequence[{}]".format(type_annotation.getter),
+            "typing.MutableSequence[{}]".format(type_annotation.getter),
             "typing.Sequence[{}]".format(type_annotation.setter),
         )
 


### PR DESCRIPTION
Before this PR, unbounded sequences of non trivial types (e.g. `std_msgs/Header[]`) would be annotated as `Sequence[T]` which is not mutable.

This would make type-checking fail on code generating such a msg, e.g.

```python

def make_header() -> std_msgs.msg.Header: ...

my_msg = Mymsg()
for i in range(10):
    my_msg.data.append(make_header())
```

This fails because there's no `append` method on `Sequence`.

By making the type annotation `MutableSequence` the problem goes away.